### PR TITLE
Add issues folder and script to pull GitHub issues locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ Thanks for contributing. Please follow these guidelines so that contributions (i
   ```
 - Open a **Pull Request** for every change; nothing should be merged by pushing directly to `main`.
 
+### Working from issues locally
+
+You can pull GitHub issues into the `issues/` folder and work from them locally; close issues by merging PRs (e.g. “Fixes #123” in the PR). From the repo root, run `./scripts/pull-issues.sh [open|closed|all]` (requires [GitHub CLI](https://cli.github.com/) and `gh auth login`). See `issues/README.md` for details.
+
 ### Pull request content
 
 Every PR must include:

--- a/issues/.gitignore
+++ b/issues/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all pulled issue exports; work from these locally but close via PRs.
+*
+!.gitignore
+!README.md

--- a/issues/README.md
+++ b/issues/README.md
@@ -1,0 +1,17 @@
+# Issues (local copy)
+
+This folder holds a **local copy** of GitHub issues for the repo. Use it to work from issue text offline; close issues by merging PRs on GitHub (e.g. “Fixes #123” in the PR).
+
+## Setup
+
+1. Install [GitHub CLI](https://cli.github.com/) and log in:
+   ```bash
+   gh auth login -h github.com
+   ```
+2. From the repo root, run:
+   ```bash
+   ./scripts/pull-issues.sh [state]
+   ```
+   `state` is `open` (default), `closed`, or `all`.
+
+Issue bodies are written as `issues/<number>.md`. The contents of this folder (except this README and `.gitignore`) are ignored by git.

--- a/scripts/pull-issues.sh
+++ b/scripts/pull-issues.sh
@@ -12,7 +12,7 @@ STATE="${1:-open}"
 mkdir -p "$ISSUES_DIR"
 cd "$REPO_ROOT"
 
-if ! command -v gh &>/dev/null; then
+if [ ! -x "$(command -v gh)" ]; then
   echo "Error: GitHub CLI (gh) is not installed. Install it and run: gh auth login"
   exit 1
 fi

--- a/scripts/pull-issues.sh
+++ b/scripts/pull-issues.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Pull all GitHub issues into the issues/ folder as markdown.
+# Requires: gh CLI, authenticated (gh auth login).
+# Usage: ./scripts/pull-issues.sh [state]
+#   state: open (default), closed, or all
+
+set -e
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ISSUES_DIR="$REPO_ROOT/issues"
+STATE="${1:-open}"
+
+mkdir -p "$ISSUES_DIR"
+cd "$REPO_ROOT"
+
+if ! command -v gh &>/dev/null; then
+  echo "Error: GitHub CLI (gh) is not installed. Install it and run: gh auth login"
+  exit 1
+fi
+
+echo "Fetching $STATE issues..."
+for num in $(gh issue list --state "$STATE" --json number --limit 500 -q '.[].number'); do
+  out="$ISSUES_DIR/${num}.md"
+  echo "  #$num -> $out"
+  gh issue view "$num" > "$out" 2>/dev/null || true
+done
+
+echo "Done. Issues are in $ISSUES_DIR (contents ignored by git)."


### PR DESCRIPTION
## Description
Add a local `issues/` folder and a script to pull GitHub issues into it so you can work from issue text locally and close issues by merging PRs (e.g. "Fixes #123").

## Feature / issue
Implements the workflow: pull issues locally, work from them, close via PR.

## How it was solved
- **`issues/`**: Contains `.gitignore` that ignores all contents except `.gitignore` and `README.md`, so exported issue files are never committed. `issues/README.md` explains setup and usage.
- **`scripts/pull-issues.sh`**: Uses GitHub CLI (`gh`) to list issues and write each to `issues/<number>.md`. Accepts state: `open` (default), `closed`, or `all`. Uses `gh`’s `-q` for parsing (no `jq` required).
- **CONTRIBUTING.md**: New subsection "Working from issues locally" with a short description and link to `issues/README.md`.

## Other methods considered
- **Root `.gitignore` only**: Ignoring `issues/` entirely would leave the folder untracked and no in-repo README; keeping the folder with an internal `.gitignore` keeps the workflow documented in the repo.
- **Node script**: Shell script was chosen to avoid extra dependencies and because `gh` is the only requirement; `-q` avoids needing `jq`.