### PR TITLE
Docs: local check commands and tooling/layout (closes #1, #2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,13 @@ Thanks for contributing. Please follow these guidelines so that contributions (i
 
 - **Node.js 24** – The project requires Node.js 24 (see `package.json` `engines` and `.nvmrc`). Use `nvm use` (or your version manager) in the repo root to switch to the correct version.
 
+## Tooling and layout
+
+- **Tests:** Vitest with `@vitest/coverage-v8`. Run tests: `npm run test` (watch) or `npm run test:coverage` (single run with coverage).
+- **Lint:** ESLint (TypeScript/React) via `eslint.config.js`. Run: `npm run lint`.
+- **Build:** `npm run build` (TypeScript + Vite).
+- **Layout:** App code under `src/`; tests are colocated (e.g. `src/App.test.tsx`) and shared setup in `src/test/`.
+
 ## Workflow
 
 ### Branching
@@ -32,6 +39,14 @@ Every PR must include:
 ## CI
 
 GitHub Actions runs on every push and pull request to `main`. The workflow runs **lint**, **test** (with coverage), and **build** in that order (fail-fast). If you push again on the same branch before the run finishes, the previous run is cancelled.
+
+**Run the same checks locally:**
+
+```bash
+npm run lint
+npm run test:coverage
+npm run build
+```
 
 ## Quality gates
 


### PR DESCRIPTION
**Description**
Updates CONTRIBUTING.md so issues #1 (CI/CD) and #2 (project bootstrap) are fully satisfied: document how to run the same checks locally as CI, and document test/lint tooling and project layout.

**Feature / issue**
Closes #1 (Set up CI/CD). Closes #2 (Project bootstrap: tooling and structure).

**How it was solved**
- Added a **Tooling and layout** section: Vitest + coverage, ESLint, build command, and that tests live under `src/` (colocated).
- Under **CI**, added **Run the same checks locally** with the exact commands: `npm run lint`, `npm run test:coverage`, `npm run build`.

**Other methods considered**
- Putting commands only in Quality gates: the new subsection under CI ties local commands directly to what CI runs. A single `npm run check` script could run all three but would duplicate CI; separate commands match the workflow steps and are already in package.json.