### PR TITLE
Docs: README, language-agnostic architecture, design-decisions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Battleship
+
+A customizable battleship game built with React and TypeScript. The app currently provides a minimal frontend; full game logic (boards, ships, turns, replay, optional AI) is planned and described in [architecture.md](architecture.md).
+
+## Requirements
+
+- **Node.js 24** – Use `nvm use` in the repo root (or your version manager) to match the version in [.nvmrc](.nvmrc).
+
+## Quick start
+
+```bash
+git clone https://github.com/mvictoria/battleship.git
+cd battleship
+nvm use          # or fnm use / volta pin
+npm install
+npm run dev
+```
+
+Open [http://localhost:5173](http://localhost:5173) in your browser.
+
+## Scripts
+
+| Command | Description |
+|--------|-------------|
+| `npm run dev` | Start dev server (Vite) |
+| `npm run build` | Type-check and build for production |
+| `npm run preview` | Preview production build locally |
+| `npm run lint` | Run ESLint |
+| `npm run test` | Run tests in watch mode |
+| `npm run test:coverage` | Run tests once with coverage report |
+
+## Project structure
+
+- **`src/`** – React app and colocated tests (e.g. `App.tsx`, `App.test.tsx`); shared test setup in `src/test/`.
+- **`docs/`** – Design decisions and other documentation.
+- **`architecture.md`** – Target game design (modules, classes, behavior); may be implemented in TypeScript or a separate backend (see [docs/design-decisions.md](docs/design-decisions.md)).
+
+## Documentation
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) – How to contribute, branch, open PRs, and run lint/tests locally.
+- [architecture.md](architecture.md) – Game architecture and module design.
+- [docs/design-decisions.md](docs/design-decisions.md) – Technology and structure choices (e.g. React, TypeScript).
+
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR. All changes go through pull requests; tests and lint must pass (see CI in CONTRIBUTING).

--- a/architecture.md
+++ b/architecture.md
@@ -2,33 +2,37 @@
 
 ## Overview
 
-This document describes the architecture, classes, and modules for a customizable battleship game. The game supports multiple players (human and computer), configurable board sizes, ship configurations, shot options, replay functionality, and an AI assistant for shot suggestions.
+This document describes the **target** architecture, classes, and modules for a customizable battleship game. The game supports multiple players (human and computer), configurable board sizes, ship configurations, shot options, replay functionality, and an AI assistant for shot suggestions.
 
 The system is designed with separation of concerns: game logic is separate from rendering, configuration is centralized, and advanced features are modular and optional.
 
-## Module Structure
+**Current repo:** The codebase is a **TypeScript/React** frontend (see [README](README.md) and [docs/design-decisions.md](docs/design-decisions.md)). The module structure below is language-agnostic; game logic may be implemented in TypeScript or in a separate backend (e.g. Python).
+
+## Module Structure (target design)
+
+Modules may be implemented as TypeScript (e.g. `cell.ts`) or Python (e.g. `cell.py`) depending on where the game logic lives.
 
 ```
 battleship/
-├── main.py              # Entry point - main() function
-├── config.py            # GameConfig, ShipConfig, PlayerConfig
-├── cell.py              # Cell class
-├── ship.py              # Ship class
-├── board.py             # Board class
-├── player.py            # Player base class
-├── ai_player.py         # AIPlayer (extends Player)
-├── shot.py              # Shot, ShotResult
-├── weapon.py            # Weapon, WeaponManager (optional)
-├── game.py              # Game main controller
-├── game_history.py      # GameHistory, GameAction (replay)
-├── shot_advisor.py      # ShotAdvisor (suggestions)
-├── ship_placer.py       # ShipPlacer (placement logic)
-└── renderer.py          # GameRenderer, SpriteManager
+├── main                 # Entry point - main()
+├── config               # GameConfig, ShipConfig, PlayerConfig
+├── cell                 # Cell class
+├── ship                 # Ship class
+├── board                # Board class
+├── player               # Player base class
+├── ai_player            # AIPlayer (extends Player)
+├── shot                 # Shot, ShotResult
+├── weapon               # Weapon, WeaponManager (optional)
+├── game                 # Game main controller
+├── game_history         # GameHistory, GameAction (replay)
+├── shot_advisor         # ShotAdvisor (suggestions)
+├── ship_placer          # ShipPlacer (placement logic)
+└── renderer             # GameRenderer, SpriteManager
 ```
 
 ## Core Classes
 
-### Cell (`cell.py`)
+### Cell (`cell`)
 
 **Purpose**: Represents a single cell/square on the game board.
 
@@ -53,7 +57,7 @@ battleship/
 
 ---
 
-### Ship (`ship.py`)
+### Ship (`ship`)
 
 **Purpose**: Represents a ship/boat on the board with its state and position.
 
@@ -82,7 +86,7 @@ battleship/
 
 ---
 
-### Board (`board.py`)
+### Board (`board`)
 
 **Purpose**: Represents a player's game board containing cells and ships.
 
@@ -111,7 +115,7 @@ battleship/
 
 ---
 
-### Player (`player.py`)
+### Player (`player`)
 
 **Purpose**: Base class representing a player (human or computer).
 
@@ -137,7 +141,7 @@ battleship/
 
 ---
 
-### GameConfig (`config.py`)
+### GameConfig (`config`)
 
 **Purpose**: Centralized configuration for all game settings and options.
 
@@ -169,7 +173,7 @@ battleship/
 
 ---
 
-### ShipConfig (`config.py`)
+### ShipConfig (`config`)
 
 **Purpose**: Configuration for a single ship type.
 
@@ -184,7 +188,7 @@ battleship/
 
 ---
 
-### PlayerConfig (`config.py`)
+### PlayerConfig (`config`)
 
 **Purpose**: Configuration for a single player.
 
@@ -199,7 +203,7 @@ battleship/
 
 ---
 
-### Game (`game.py`)
+### Game (`game`)
 
 **Purpose**: Main game controller that orchestrates the entire game flow.
 
@@ -238,7 +242,7 @@ battleship/
 
 ---
 
-### GameRenderer (`renderer.py`)
+### GameRenderer (`renderer`)
 
 **Purpose**: Handles all rendering and display of the game state.
 
@@ -265,7 +269,7 @@ battleship/
 
 ---
 
-### SpriteManager (`renderer.py`)
+### SpriteManager (`renderer`)
 
 **Purpose**: Manages sprite/image assets for different themes.
 
@@ -288,7 +292,7 @@ battleship/
 
 ## Advanced Classes
 
-### AIPlayer (`ai_player.py`)
+### AIPlayer (`ai_player`)
 
 **Purpose**: Computer-controlled player with configurable difficulty levels.
 
@@ -316,7 +320,7 @@ battleship/
 
 ---
 
-### Shot (`shot.py`)
+### Shot (`shot`)
 
 **Purpose**: Represents a single shot fired at the board.
 
@@ -337,7 +341,7 @@ battleship/
 
 ---
 
-### ShotResult (`shot.py`)
+### ShotResult (`shot`)
 
 **Purpose**: Result of a shot fired at the board.
 
@@ -353,7 +357,7 @@ battleship/
 
 ---
 
-### Weapon (`weapon.py`) - Optional
+### Weapon (`weapon`) – optional
 
 **Purpose**: Represents a weapon that can hit multiple squares (alternative to standard single-shot).
 
@@ -372,7 +376,7 @@ battleship/
 
 ---
 
-### WeaponManager (`weapon.py`) - Optional
+### WeaponManager (`weapon`) – optional
 
 **Purpose**: Manages available weapons.
 
@@ -385,7 +389,7 @@ battleship/
 
 ---
 
-### GameHistory (`game_history.py`)
+### GameHistory (`game_history`)
 
 **Purpose**: Tracks all game actions for replay functionality.
 
@@ -407,7 +411,7 @@ battleship/
 
 ---
 
-### GameAction (`game_history.py`)
+### GameAction (`game_history`)
 
 **Purpose**: Represents a single action in game history.
 
@@ -423,7 +427,7 @@ battleship/
 
 ---
 
-### ShotAdvisor (`shot_advisor.py`)
+### ShotAdvisor (`shot_advisor`)
 
 **Purpose**: Suggests optimal shot placements based on probability calculations.
 
@@ -450,7 +454,7 @@ battleship/
 
 ---
 
-### ShipPlacer (`ship_placer.py`)
+### ShipPlacer (`ship_placer`)
 
 **Purpose**: Handles ship placement logic and validation.
 

--- a/docs/design-decisions.md
+++ b/docs/design-decisions.md
@@ -11,7 +11,7 @@ This document records significant technology and structure choices for the proje
 - TypeScript provides static typing, better editor support, and clearer contracts for game state and components.
 
 **Implications:**
-- All UI code lives under a standard TypeScript/React folder structure (see repo root and CONTRIBUTING).
+- All UI code lives under a standard TypeScript/React folder structure (see [README](../README.md) and [CONTRIBUTING](../CONTRIBUTING.md)).
 - New UI code must be in TypeScript (`.ts`/`.tsx`); the project enforces TS standards for structure and typing.
 - Game logic may live in the frontend (TypeScript) or in a separate backend (e.g. Python per `architecture.md`); integration approach TBD.
 


### PR DESCRIPTION
**Description**
Adds a project README and updates docs so the architecture is language-agnostic (no .py-only references). Aligns docs with the current TypeScript/React repo.

**Feature / issue**
Documentation: README for the project; reducing drift between architecture (target game design) and current stack (TS/React).

**How it was solved**
- **README.md:** Description, requirements (Node 24), quick start (clone, nvm use, npm install, npm run dev), scripts table, project structure, links to CONTRIBUTING, architecture, design-decisions.
- **architecture.md:** Overview states doc is target design; added note that modules may be implemented as .ts or .py. Module tree and all class headers use extensionless names (e.g. `cell` not `cell.py`). One sentence explains implementations may be TypeScript or Python.
- **docs/design-decisions.md:** Replaced "see repo root and CONTRIBUTING" with links to README and CONTRIBUTING.

**Other methods considered**
- Leaving architecture as Python-only: rejected so the doc stays valid whether game logic is implemented in TS or a separate backend. Keeping a single `cell.py` / `cell.ts` example in the intro was preferred over duplicating the tree for both languages.